### PR TITLE
Add Tox: Include tox for multiversion testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 build/
 coverage/
 nosetests.xml
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Configuration for Travis CI
+# When making changes, make sure to also edit tox.ini file.
+
 language: python
 
 python:

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,31 @@ Or can be installed using easy_install::
 
     $ easy_install aweber_api
 
+
+Testing
+=======
+
+Place the client library into a virtualenv and execute the test suite by running the following command::
+
+    $ python setup.py nosetests
+
+Also, the project can use tox to run against multiple versions of python.  The tox package is available 
+from pypi here::
+
+    https://pypi.python.org/pypi/tox
+
+Instructions for how to use and configure tox can be found here::
+
+    http://tox.readthedocs.org/en/latest/#
+
+Currently, running tox will require that both python 2.6 and python 2.7 are installed.
+
+Additional interpreters may be installed and the tox.ini file must be modified to include the
+newly added interpreters.  Once the interpreters are installed, the tests can be run via::
+
+    $ tox
+
+
 Usage
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     packages=find_packages(exclude=['tests']),
     install_requires=[
-        'httplib2>=0.7.0',
+        'httplib2>=0.7.0,<=0.8.0',
         'oauth2>=1.2',
     ],
     tests_require=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+#  When making changes, make sure to also edit the .travis.yml file.
+
+[tox]
+envlist = py26, py27
+
+[testenv]
+commands = python setup.py nosetests []
+
+deps =
+    nose
+    httplib2>=0.7.0,<=0.8.0
+    oauth2>=1.2
+    unittest2
+    coverage
+    dingus


### PR DESCRIPTION
Add tox.ini file to enable multiversion testing. The done state for this card is to enable tox for python version 2.6 only. An additional card in this sprint will cover adding python version 2.7, and 3.3.
#### For testing,

get the latest build and this branch
run in a virtualenv with python 2.6 installed
run the command
$ tox
#### test results

the results of executing the above command and verifying passing tests should be this:

```
$ tox

|Name|Stmts|Miss|Cover|Missing|
|--------|--------|------|-------|-----------|
|aweber_api| 59| 14| 76% |28-46, 57, 90, 95|
|aweber_api.base| 29| 0| 100%| 
|aweber_api.collection| 86| 16| 81%| 43-45, 48-58, 101-102, 127, 131|
|aweber_api.data_dict|10|0 |100%|
|aweber_api.entry |83 |0 |100%|
|aweber_api.oauth |68 |9 |87% |21, 23-25, 36-39, 70, 75|
|aweber_api.response| 21| 1| 95%| 29|

TOTAL 356 40 89%

Ran 77 tests in 0.421s

OK
summary ---
py26: commands succeeded
congratulations :)
```
