### PR TITLE
Remove dingus and replace with Mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'oauth2>=1.2',
     ],
     tests_require=[
-        'dingus',
+        'mock',
         'coverage',
     ],
     setup_requires=[

--- a/tests/mock_adapter.py
+++ b/tests/mock_adapter.py
@@ -1,7 +1,9 @@
 import json
 import os
+from urlparse import urlparse, parse_qs
+from urllib import quote
 
-import dingus
+import mock
 
 from aweber_api import AWeberUser
 from aweber_api import OAuthAdapter
@@ -15,9 +17,8 @@ responses = {
         '/accounts/1':                              ({}, 'accounts/1'),
         '/accounts/1?ws.op=findSubscribers&' \
                          'email=joe%40example.com': ({}, 'accounts/findSubscribers'),
-        '/accounts/1?ws.op=findSubscribers&' \
-                         'email=joe%40example.com&' \
-                         'ws.show=total_size': ({}, 'accounts/findSubscribers_ts'),
+        '/accounts/1?ws.show=total_size&ws.op=findSubscribers&' \
+                         'email=joe%40example.com': ({}, 'accounts/findSubscribers_ts'),
         '/accounts/1?ws.op=getWebForms':             ({}, 'accounts/webForms'),
         '/accounts/1?ws.op=getWebFormSplitTests':    ({}, 'accounts/webFormSplitTests'),
         '/accounts/1/lists':                         ({}, 'lists/page1'),
@@ -37,7 +38,7 @@ responses = {
         '/accounts/1/lists/505454/subscribers/3':    ({}, 'subscribers/3'),
         '/accounts/1/lists/303449/subscribers/1?ws.op=getActivity': (
             {}, 'subscribers/get_activity'),
-        '/accounts/1/lists/303449/subscribers/1?ws.op=getActivity&ws.show=total_size': (
+        '/accounts/1/lists/303449/subscribers/1?ws.show=total_size&ws.op=getActivity': (
             {}, 'subscribers/get_activity_ts'),
         '/accounts/1/lists/303449/subscribers?ws.op=find&name=joe': (
             {'status': '400'}, 'error'),
@@ -45,9 +46,8 @@ responses = {
             {'status': '400'}, 'error'),
         '/accounts/1/lists/303449/subscribers?ws.op=find&' \
                          'email=joe%40example.com': ({}, 'subscribers/find'),
-        '/accounts/1/lists/303449/subscribers?ws.op=find&' \
-                         'email=joe%40example.com&' \
-                         'ws.show=total_size': ({}, 'subscribers/find_ts'),
+        '/accounts/1/lists/303449/subscribers?ws.show=total_size&ws.op=find&' \
+                         'email=joe%40example.com': ({}, 'subscribers/find_ts'),
     },
     'POST' : {
         '/accounts/1/lists/303449/any_collection':  ({
@@ -72,8 +72,24 @@ responses = {
     }
 }
 
+def _sort_qs_for_url(url):
+    """Sort query string parameters in desending order."""
+    parsed = urlparse(url)
+
+    if len(parsed.query) == 0:
+        return parsed.path
+
+    qs = parse_qs(parsed.query)
+    params = []
+    for key in reversed(sorted(qs.keys())):
+        params.append("{0}={1}".format(key, quote(qs[key][0])))
+
+    return "{0}?{1}".format(parsed.path, "&".join(params))
+
+
 def request(self, url, method, **kwargs):
     """Return a tuple to simulate calling oauth2.Client.request."""
+    url = _sort_qs_for_url(url)
     (headers, file) = responses[method][url]
     if 'status' not in headers:
         # assume 200 OK if not otherwise specified
@@ -90,9 +106,10 @@ class MockAdapter(OAuthAdapter):
     """Mocked OAuthAdapter."""
     requests = []
 
-    @dingus.patch('oauth2.Client.request', request)
+    @mock.patch('oauth2.Client.request', request)
     def request(self, method, url, data={}, response='body'):
         """Mock the oauth.Client.request method"""
+        url = _sort_qs_for_url(url)
         req = super(MockAdapter, self).request(method, url, data, response)
         self.requests.append({'method' : method, 'url' : url, 'data' : data})
         return req

--- a/tests/test_aweber_api.py
+++ b/tests/test_aweber_api.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from mock_adapter import MockAdapter
-from dingus import Dingus
+from mock import Mock
 from aweber_api import (AWeberAPI, AWeberUser, ACCESS_TOKEN_URL, AUTHORIZE_URL,
                         REQUEST_TOKEN_URL, AWeberEntry)
 
@@ -19,9 +19,9 @@ class WhenGettingARequestToken(AWeberAPITest):
     def setUp(self):
         AWeberAPITest.setUp(self)
         self.response = "oauth_token=1234&oauth_token_secret=abcd"
-        self.aweber.adapter = Dingus()
+        self.aweber.adapter = Mock()
         self.aweber.adapter.user = AWeberUser()
-        self.aweber.adapter.request = Dingus(return_value=self.response)
+        self.aweber.adapter.request = Mock(return_value=self.response)
 
     def test_should_get_request_token(self):
         token, secret = self.aweber.get_request_token('http://localhost/demo')
@@ -57,9 +57,9 @@ class WhenGettingAnAccessToken(AWeberAPITest):
     def setUp(self):
         AWeberAPITest.setUp(self)
         self.response = "oauth_token=cheeseburger&oauth_token_secret=hotdog"
-        self.aweber.adapter = Dingus()
+        self.aweber.adapter = Mock()
         self.aweber.adapter.user = AWeberUser()
-        self.aweber.adapter.request = Dingus(return_value=self.response)
+        self.aweber.adapter.request = Mock(return_value=self.response)
 
         self.aweber.user.request_token = '1234'
         self.aweber.user.token_secret = 'abcd'

--- a/tests/test_data_dict.py
+++ b/tests/test_data_dict.py
@@ -1,11 +1,11 @@
 from unittest import TestCase
 from aweber_api.data_dict import DataDict
-from dingus import Dingus
+from mock import Mock
 
 class TestDataDict(TestCase):
 
     def setUp(self):
-        self.obj = Dingus()
+        self.obj = Mock()
         self.obj.data = {}
         self.data = {
             'favorite food'  : 'Tacos',

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ deps =
     oauth2>=1.2
     unittest2
     coverage
-    dingus
+    mock


### PR DESCRIPTION
In order to achieve the milestone of python 3.3 support we'll need to start replacing dependencies that do not support python 3.3.  This pull request is step one in that direction.  

This pull request replaces the dingus mocking library with mock.  Dingus currently does not have python 3.3 support will mock does and is included in the stdlib of python 3.
