### PR TITLE
Add schedule brodcast feature

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,8 @@
 Changelog
 ---------
+2014-11-13: v1.2.0
+   * Add a new endpoint to schedule broadcast
+
 2013-01-03: v1.1.4
   * Support version 1.0.17 of the API. (Broadcast Stats)
   * See https://labs.aweber.com/docs/changelog for details

--- a/aweber_api/entry.py
+++ b/aweber_api/entry.py
@@ -121,6 +121,22 @@ class AWeberEntry(AWeberResponse):
         collection._data['total_size'] = self._get_total_size(url)
         return collection
 
+    def schedule_broadcast(self, bc_id, scheduled_for):
+        """Invoke the API method to schedule the given broadcast.
+
+        * Note:
+            This method only works on List Entry resources and
+            requires access to subscriber information. Please
+            refer to the AWeber API Reference Documentation at
+            https://labs.aweber.com/docs/reference/1.0#account
+            for more details on how to call this method.
+
+        """
+        self._method_for('list')
+        body = {'scheduled_for': scheduled_for}
+        url = '{0}/broadcasts/{1}/schedule'.format(self.url, bc_id)
+        return self.adapter.request('POST', url, body, response='status')
+
     def _get_total_size(self, uri, **kwargs):
         """Get actual total size number from total_size_link."""
         total_size_uri = '{0}&ws.show=total_size'.format(uri)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if version < '2.2.3':
 
 setup(
     name='aweber_api',
-    version='1.1.4',
+    version='1.2.0',
     author='AWeber Dev Team',
     author_email='api@aweber.com',
     maintainer='AWeber API Team',

--- a/tests/mock_adapter.py
+++ b/tests/mock_adapter.py
@@ -61,6 +61,17 @@ responses = {
         '/accounts/1/lists/303449/subscribers/1': ({
             'status': '201',
             'location': '/accounts/1/lists/505454/subscribers/3'}, None),
+        '/accounts/1/lists/303449/broadcasts/2/schedule': ({
+            'status': '201',
+            'location': '/accounts/1/lists/303449/broadcasts/2/schedule'},
+            None
+        ),
+        '/accounts/1/lists/303449/broadcasts/3/schedule': ({
+            'status': '400',
+            'location': '/accounts/1/lists/303449/broadcasts/3/schedule'},
+            'error'
+        ),
+
     },
     'PATCH' : {
         '/accounts/1/lists/303449/subscribers/1': ({'status': '209'}, None),


### PR DESCRIPTION
This method schedules a broadcast message to be sent.

For more information see the [broadcast scheduler documentation](https://labs.aweber.com/docs/reference/1.0#Broadcast%20Scheduler) on the AWeber Labs site.
