### PR TITLE
Add cancel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
-Changelog
----------
+2014-11-17: v1.3.0
+   * Add a new endpoint to cancel scheduled broadcast
+
 2014-11-20 v1.2.1
   * Removed SSL Certificate workaround
   * Upgraded httplib2 >= 0.9.0

--- a/aweber_api/entry.py
+++ b/aweber_api/entry.py
@@ -128,7 +128,7 @@ class AWeberEntry(AWeberResponse):
             This method only works on List Entry resources and
             requires access to subscriber information. Please
             refer to the AWeber API Reference Documentation at
-            https://labs.aweber.com/docs/reference/1.0#account
+            https://labs.aweber.com/docs/reference/1.0#broadcast_scheduler
             for more details on how to call this method.
 
         """
@@ -136,6 +136,22 @@ class AWeberEntry(AWeberResponse):
         body = {'scheduled_for': scheduled_for}
         url = '{0}/broadcasts/{1}/schedule'.format(self.url, bc_id)
         return self.adapter.request('POST', url, body, response='status')
+
+    def cancel_broadcast(self, bc_id):
+        """Invoke the API method to cancel the given scheduled broadcast.
+
+        * Note:
+            This method only works on List Entry resources and
+            requires access to subscriber and send broadcast
+            information. Please refer to the AWeber API Reference
+            Documentation at
+            https://labs.aweber.com/docs/reference/1.0#cancel_broadcast
+            more details on how to call this method.
+
+        """
+        self._method_for('list')
+        url = '{0}/broadcasts/{1}/cancel'.format(self.url, bc_id)
+        return self.adapter.request('POST', url, data={}, response='status')
 
     def _get_total_size(self, uri, **kwargs):
         """Get actual total size number from total_size_link."""

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if version < '2.2.3':
 
 setup(
     name='aweber_api',
-    version='1.2.1',
+    version='1.3.0',
     author='AWeber Dev Team',
     author_email='api@aweber.com',
     maintainer='AWeber API Team',

--- a/tests/mock_adapter.py
+++ b/tests/mock_adapter.py
@@ -71,6 +71,16 @@ responses = {
             'location': '/accounts/1/lists/303449/broadcasts/3/schedule'},
             'error'
         ),
+        '/accounts/1/lists/303449/broadcasts/2/cancel': ({
+            'status': '204',
+            'location': '/accounts/1/lists/303449/broadcasts/2/cancel'},
+            None
+        ),
+        '/accounts/1/lists/303449/broadcasts/3/cancel': ({
+            'status': '400',
+            'location': '/accounts/1/lists/303449/broadcasts/3/cancel'},
+            'error'
+        ),
 
     },
     'PATCH' : {

--- a/tests/test_aweber_entry.py
+++ b/tests/test_aweber_entry.py
@@ -160,6 +160,44 @@ class TestListScheduleBroadcastError(ListTestCase):
         )
 
 
+class TestListCancelBroadcast(ListTestCase):
+
+    def setUp(self):
+        super(TestListCancelBroadcast, self).setUp()
+        self.aweber.adapter.requests = []
+        self.status = self.list_.cancel_broadcast(bc_id=2)
+        self.request = self.aweber.adapter.requests[0]
+
+    def test_should_return_status(self):
+        self.assertEqual(int(self.status), 204)
+
+    def test_should_make_post_request(self):
+        self.assertEqual(self.request['method'], 'POST')
+
+    def test_should_build_correct_url(self):
+            self.assertEqual(self.request['url'],
+            '/accounts/1/lists/303449/broadcasts/2/cancel'
+        )
+
+    def test_should_pass_empty_date(self):
+            self.assertEqual(self.request['data'], {})
+
+
+class TestListCancelBroadcastError(ListTestCase):
+
+    def setUp(self):
+        super(TestListCancelBroadcastError, self).setUp()
+        self.list_ = self.aweber.load_from_url('/accounts/1/lists/303449')
+        self.aweber.adapter.requests = []
+
+    def test_should_raise_exception_when_failing(self):
+        self.assertRaises(
+            APIException,
+            self.list_.cancel_broadcast,
+            bc_id=3,
+        )
+
+
 class SubscriberTestCase(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This method cancels a broadcast message scheduled to be sent.

For more information see the cancel broadcast [documentation](https://labs.aweber.com/docs/reference/1.0) on the AWeber Labs site.
